### PR TITLE
Increase lint timeout

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -82,7 +82,7 @@ tasks:
     cmds:
     - GOGC=100 golangci-lint run ./... --timeout {{ .TIMEOUT }} {{ .CLI_ARGS }}
     vars:
-      TIMEOUT: 1m
+      TIMEOUT: 2m
     sources:
     - cmd/**/*
     - internal/**/*


### PR DESCRIPTION
The linter takes way too long!

Ideally I find a way to speed it up or otherwise will need to remove
linters that provide less value.